### PR TITLE
Remove deprecated loop argument inside Lock()

### DIFF
--- a/asyncpio.py
+++ b/asyncpio.py
@@ -929,9 +929,9 @@ class _socklock:
    """
    A class to store socket and lock.
    """
-   def __init__(self, loop=None):
+   def __init__(self):
       self.s = None
-      self.l = asyncio.Lock(loop=loop)
+      self.l = asyncio.Lock()
 
 class error(Exception):
    """pigpio module exception"""


### PR DESCRIPTION
fixes #1 

removing loop=loop inside Lock() fixes the error message. This may, however, break a lot of stuff downstream as it did for this repo